### PR TITLE
Fix x-out icon

### DIFF
--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -21,7 +21,7 @@ function Modal({ children, onDismiss, ...props }: DialogOverlayProps) {
           onClick={onDismiss}
           aria-label="close modal"
         >
-          <CloseIcon tw="w-4 h-4 m-auto stroke-gray-yellow-400 group-hover:stroke-copper-300" />
+          <CloseIcon tw="w-4 h-4 m-auto fill-gray-yellow-400 group-hover:fill-copper-300" />
         </button>
         {children}
       </DialogContent>

--- a/src/icons/close-icon.svg
+++ b/src/icons/close-icon.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="#A49989" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 8.00001L16 14L14 16L8.00001 10L2 16L4.17233e-07 14L6.00001 8.00001L0 2L2 0L8.00001 6.00001L14 0L16 2L10 8.00001Z" fill="#A49989"/>
+</svg>

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -6,7 +6,7 @@ import SearchIcon from './search-icon.svg'
 import SpinnerIcon from './spinner.svg'
 import GearIcon from './gear-icon.svg'
 import UpdateLinkIcon from './update-link-icon.svg'
-import CloseIcon from './x-out.svg'
+import CloseIcon from './close-icon.svg'
 import CameraIcon from './camera-icon.svg'
 import DeleteIcon from './delete-icon.svg'
 

--- a/src/icons/x-out.svg
+++ b/src/icons/x-out.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#A49989" xmlns="http://www.w3.org/2000/svg">
-<line x1="2.06066" y1="1.93934" x2="14.7886" y2="14.6673" stroke="inherit" stroke-width="3"/>
-<line x1="1.93934" y1="14.6674" x2="14.6673" y2="1.93945" stroke="inherit" stroke-width="3"/>
-</svg>


### PR DESCRIPTION
Fix #108
- [x] Rename it to `close-icon.svg`
- [x] Upload new svg that uses fill instead of stroke
- [x] Change from stroke to fill where it is used in `modal.tsx`